### PR TITLE
Allow :file key in faces_recognize

### DIFF
--- a/lib/face/client/recognition.rb
+++ b/lib/face/client/recognition.rb
@@ -8,7 +8,7 @@ module Face
       end
 
       def faces_recognize(opts={})
-        opts.assert_valid_keys(:uids, :urls, :namespace, :detector, :attributes, :callback, :callback_url)
+        opts.assert_valid_keys(:uids, :file, :urls, :namespace, :detector, :attributes, :callback, :callback_url)
         make_request(:faces_recognize, opts.merge(user_auth_param))
       end
 


### PR DESCRIPTION
This patch allows the faces_recognize method to take a file descriptor (not only uri), so we can also use local files for recognition.
