### PR TITLE
Switch to SkyBiometry Face Detection and Recognition API

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,6 +1,6 @@
-Note: This gem is still under development , create issues if you meet any problem when using it https://github.com/rociiu/face/issues
+Note: This gem is still under development, create issues if you meet any problem when using it https://github.com/rociiu/face/issues
 
-Face is a ruby library of http://developers.face.com/.
+Face is a ruby library of SkyBiometry Face Detection and Recognition API.
 
 == Getting Started
   
@@ -18,11 +18,6 @@ Detect Faces with Raw image data:
 
   >> client.faces_detect(:file => File.new('image.jpg', 'rb'))
  
-With user auth:
-
-  >> client.twitter_credentials = { :twitter_username => 'twitter_screen_name', :twitter_password => 'twitter_password' }
-  >> client.faces_recognize(:urls => ['http://test.com/1.jpg'], :uids => ['uiicor']) # will make request with twitter credentials
-
-More Documentation refer to http://developers.face.com/.
+More Documentation refer to http://www.skybiometry.com/Documentation.
 
 Author: Roc Yu (rociiu.yu@gmail.com)

--- a/face.gemspec
+++ b/face.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.authors     = ["Roc Yu"]
   s.email       = ["rociiu.yu@gmail.com"]
   s.homepage    = "http://rubygems.org/gems/face"
-  s.summary     = %q{Ruby wraper of face.com api}
+  s.summary     = %q{Ruby wraper of SkyBiometry Face Detection and Recognition API}
   s.description = %q{}
 
   s.rubyforge_project = "face"

--- a/lib/face/client/recognition.rb
+++ b/lib/face/client/recognition.rb
@@ -1,7 +1,6 @@
 module Face
   module Client
     module Recognition
-      # http://api.face.com/faces/detect.json
       def faces_detect(opts={})
         opts.assert_valid_keys(:urls, :file, :detector, :attributes, :callback, :callback_url)
         make_request(:faces_detect, opts)

--- a/lib/face/client/utils.rb
+++ b/lib/face/client/utils.rb
@@ -5,16 +5,16 @@ module Face
       class FaceError < StandardError; end
 
       API_METHODS = {
-        :faces_detect => 'http://api.face.com/faces/detect.json',
-        :faces_recognize => 'http://api.face.com/faces/recognize.json',
-        :faces_train => 'http://api.face.com/faces/train.json',
-        :faces_status => 'http://api.face.com/faces/status.json',
-        :tags_get => 'http://api.face.com/tags/get.json',
-        :tags_add => 'http://api.face.com/tags/add.json',
-        :tags_save => 'http://api.face.com/tags/save.json',
-        :tags_remove => 'http://api.face.com/tags/remove.json',
-        :account_limits => 'http://api.face.com/account/limits.json',
-        :account_users => 'http://api.face.com/account/users.json'
+        :faces_detect => 'http://api.skybiometry.com/fc/faces/detect.json',
+        :faces_recognize => 'http://api.skybiometry.com/fc/faces/recognize.json',
+        :faces_train => 'http://api.skybiometry.com/fc/faces/train.json',
+        :faces_status => 'http://api.skybiometry.com/fc/faces/status.json',
+        :tags_get => 'http://api.skybiometry.com/fc/tags/get.json',
+        :tags_add => 'http://api.skybiometry.com/fc/tags/add.json',
+        :tags_save => 'http://api.skybiometry.com/fc/tags/save.json',
+        :tags_remove => 'http://api.skybiometry.com/fc/tags/remove.json',
+        :account_limits => 'http://api.skybiometry.com/fc/account/limits.json',
+        :account_users => 'http://api.skybiometry.com/fc/account/users.json'
       }
 
       def api_crendential

--- a/lib/face/version.rb
+++ b/lib/face/version.rb
@@ -1,3 +1,3 @@
 module Face
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end


### PR DESCRIPTION
SkyBiometry Face Detection And Recognition API is intended to be used as a drop-in replacement for developers using face.com API. I would like to suggest to switch to this service because face.com API is no longer available.
